### PR TITLE
Remove DescribeVolumesInput.VolumeType default tag

### DIFF
--- a/service/volume.go
+++ b/service/volume.go
@@ -262,7 +262,7 @@ type DescribeVolumesInput struct {
 	// Verbose's available values: 0, 1
 	Verbose *int `json:"verbose" name:"verbose" default:"0" location:"params"`
 	// VolumeType's available values: 0, 1, 2, 3
-	VolumeType *int      `json:"volume_type" name:"volume_type" default:"0" location:"params"`
+	VolumeType *int      `json:"volume_type" name:"volume_type" location:"params"`
 	Volumes    []*string `json:"volumes" name:"volumes" location:"params"`
 }
 


### PR DESCRIPTION
DescribeVolumesInput.VolumeType 的 default tag 导致无法获取全部类型硬盘，比如下面这个请求

```
INFO -- : Built QingCloud request: [0] https://api.qingcloud.com:443/iaas?action=DescribeVolumes&limit=20&offset=0&verbose=0&volume_type=0&volumes.1=vol-xp8u3r6y&zone=sh1a
```