### PR TITLE
Delete DescribeSecurityGroupRules direction default value.

### DIFF
--- a/service/security_group.go
+++ b/service/security_group.go
@@ -634,7 +634,7 @@ type DescribeSecurityGroupRulesInput struct {
 	Direction          *int      `json:"direction" name:"direction" location:"params"`
 	Limit              *int      `json:"limit" name:"limit" default:"20" location:"params"`
 	Offset             *int      `json:"offset" name:"offset" default:"0" location:"params"`
-	SecurityGroup      *string   `json:"security_group" name:"security_group" location:"params"` // Required
+	SecurityGroup      *string   `json:"security_group" name:"security_group" location:"params"`
 	SecurityGroupRules []*string `json:"security_group_rules" name:"security_group_rules" location:"params"`
 }
 
@@ -657,13 +657,6 @@ func (v *DescribeSecurityGroupRulesInput) Validate() error {
 				ParameterValue: directionParameterValue,
 				AllowedValues:  directionValidValues,
 			}
-		}
-	}
-
-	if v.SecurityGroup == nil {
-		return errors.ParameterRequiredError{
-			ParameterName: "SecurityGroup",
-			ParentName:    "DescribeSecurityGroupRulesInput",
 		}
 	}
 


### PR DESCRIPTION
According to https://docs.qingcloud.com/api/sg/describe_security_group_rules.html.
If no filtering conditions are specified , by default, return all the rules for all the SecurityGroup you have .
So , SecurityGroup should not be required .