### PR TITLE
Fix unpack http request panic

### DIFF
--- a/request/unpacker.go
+++ b/request/unpacker.go
@@ -81,8 +81,8 @@ func (u *Unpacker) parseError() error {
 	retCodeValue := u.output.Elem().FieldByName("RetCode")
 	messageValue := u.output.Elem().FieldByName("Message")
 
-	if retCodeValue.IsValid() && retCodeValue.Type().String() == "*int" &&
-		messageValue.IsValid() && messageValue.Type().String() == "*string" &&
+	if retCodeValue.Elem().IsValid() && retCodeValue.Type().String() == "*int" &&
+		messageValue.Elem().IsValid() && messageValue.Type().String() == "*string" &&
 		retCodeValue.Elem().Int() != 0 {
 
 		return &errors.QingCloudError{

--- a/request/unpacker_test.go
+++ b/request/unpacker_test.go
@@ -79,6 +79,7 @@ func TestUnpackerUnpackHTTPRequest(t *testing.T) {
 		RetCode    *int      `json:"ret_code" name:"ret_code"`
 		TotalCount *int      `json:"total_count" name:"total_count"`
 		VolumeSet  []*Volume `json:"volume_set" name:"volume_set"`
+		Message    *string   `json:"message" name:"message"`
 	}
 
 	httpResponse := &http.Response{Header: http.Header{}}


### PR DESCRIPTION
Fix [issues95](https://github.com/yunify/qingcloud-sdk-go/issues/95)

When `retCodeValue := u.output.Elem().FieldByName("RetCode")` return nil,
The `retCodeValue.IsValid()` still return True, 
Which will cause `retCodeValue.Elem().Int()` panic because the kind of `retCodeValue.Elem()` is struct when retCodeValue is nil.