### PR TITLE
[fix]: set content-length after write signature

### DIFF
--- a/request/signer.go
+++ b/request/signer.go
@@ -54,6 +54,7 @@ func (is *Signer) WriteSignature(request *http.Request) error {
 	}
 	request.URL = newRequest.URL
 	request.Body = newRequest.Body
+	request.ContentLength = newRequest.ContentLength
 
 	logger.Info(fmt.Sprintf(
 		"Signed QingCloud request: [%d] %s",


### PR DESCRIPTION
The request of POST method dosen't set content-length value, this would case 411 error with apache server.